### PR TITLE
Allow user to set up VNC screen geometry

### DIFF
--- a/standalone/start.sh
+++ b/standalone/start.sh
@@ -11,7 +11,7 @@ cleanup() {
 
 vncserver $DISPLAY -noxstartup \
                    -securitytypes none \
-                   -geometry 1600x900 \
+                   -geometry "${VNC_GEOMETRY:-1600x900}" \
                    -depth 16 \
                    -alwaysshared &
 


### PR DESCRIPTION
In Subscriptions, we are considering running tests in wider browser. I discovered that screen size is hardcoded in container image, and it would be silly for us to build and deploy our own image with this single change. Users should be allowed to change screen size when running container.

With this patch, it is possible. You can pass `-e VNC_GEOMETRY=WIDTHxHEIGHT` to force specific screen geometry:

```
podman run -e VNC_GEOMETRY=600x480 selenium-standalone
```

If argument is not passed, default value of 1600x900 is used. So there are no changes needed for people who don't want to use this feature.