### PR TITLE
selenium jars are kept in major.minor.0 directory

### DIFF
--- a/grid/base/Dockerfile
+++ b/grid/base/Dockerfile
@@ -23,6 +23,7 @@ RUN PACKAGES="\
     microdnf clean all
 
 RUN mkdir -p /opt/selenium/ && \
+    SELENIUM_VERSION_DIRECTORY=${SELENIUM_MAJOR_VERSION}.${SELENIUM_MINOR_VERSION}.0 && \
     SELENIUM_VERSION=${SELENIUM_MAJOR_VERSION}.${SELENIUM_MINOR_VERSION}.${SELENIUM_PATCH_VERSION} && \
-    curl -L https://github.com/SeleniumHQ/selenium/releases/download/selenium-${SELENIUM_VERSION}/selenium-server-${SELENIUM_VERSION}.jar \
+    curl -L https://github.com/SeleniumHQ/selenium/releases/download/selenium-${SELENIUM_VERSION_DIRECTORY}/selenium-server-${SELENIUM_VERSION}.jar \
          -o ${SELENIUM_PATH}


### PR DESCRIPTION
Currently, the jars are saved in the location as https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.1.0/selenium-server-4.1.2.jar. I have raised the concern here https://github.com/SeleniumHQ/selenium/issues/9528#issuecomment-1025741701. Till time we have to fix this unless it is fixed there end.   