### PR TITLE
fix firefox in standalone selenium image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     types: ["opened", "synchronize", "reopened"]
 
 jobs:
-  build:
+  test-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,3 +18,6 @@ jobs:
           dockerfiles: standalone/Dockerfile
           context: standalone
           oci: true
+      - name: Test if firefox runs without errors
+        run: |
+          podman run -it --rm selenium-standalone:latest firefox --version | grep 'Mozilla Firefox'

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -111,6 +111,7 @@ RUN PACKAGES="\
         libXpm \
         libXrandr \
         libXrender \
+        libXtst \
         libxshmfence \
         libXt \
         mesa-libgbm \


### PR DESCRIPTION
There is missing dependency for firefox in selenium-standalone image:
```
bash-5.1$ firefox-bin 
XPCOMGlueLoad error for file /home/selenium/firefox/libxul.so:
libXtst.so.6: cannot open shared object file: No such file or directory
Couldn't load XPCOM.
```
We need to build new image with libXtst installed.